### PR TITLE
latest warnings from uspecial.h has been resolved

### DIFF
--- a/uspecial.h
+++ b/uspecial.h
@@ -158,10 +158,10 @@ template <size_t NX, size_t NY, typename T>
 void matrix<NX,NY,T>::text_write (ostringstream& os) const
 {
     os << '(';
-    for (uoff_t row = 0; row < NY; ++ row) {
+    for (uoff_t iRow = 0; iRow < NY; ++ iRow) {
 	os << '(';
-        for (uoff_t column = 0; column < NX; ++column)
-	    os << at(row)[column] << ",)"[column == NX-1];
+        for (uoff_t iColumn = 0; iColumn < NX; ++iColumn)
+	    os << at(iRow)[iColumn] << ",)"[iColumn == NX-1];
     }
     os << ')';
 }


### PR DESCRIPTION
`test/../uspecial.h: In member function ‘void ustl::matrix<NX,NY,T>::text_write(ustl::ostringstream&) const’:`
`test/../uspecial.h:161:17: warning: declaration of ‘row’ shadows a member of 'this' [-Wshadow]`
`test/../uspecial.h:163:21: warning: declaration of ‘column’ shadows a member of 'this' [-Wshadow]`


