### PR TITLE
Fix clang warning in UTF-8 converter

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -44,7 +44,8 @@ inline size_t Utf8Bytes (wchar_t v)
 	    "div\t%3":"=a"(n),"+d"(r):"r"(v),"c"(5));
     #else
 	static const uint32_t c_Bounds[7] = { 0x0000007F, 0x000007FF, 0x0000FFFF, 0x001FFFFF, 0x03FFFFFF, 0x7FFFFFFF, 0xFFFFFFFF };
-	for (n = 0; c_Bounds[n++] < uint32_t(v););
+	for (n = 0; c_Bounds[n++] < uint32_t(v);)
+		;
     #endif
     return n;
 }


### PR DESCRIPTION
Clang 9 generates the following diagnostic:

```
libustl/ustl/utf8.h:47:43: warning: for loop has empty body [-Wempty-body]
       for (n = 0; c_Bounds[n++] < uint32_t(v););
                                                ^
libustl/ustl/utf8.h:47:43: note: put the semicolon on a separate line to silence this warning
1 warning generated.
```